### PR TITLE
Adds center support

### DIFF
--- a/lib/Colors/Color.php
+++ b/lib/Colors/Color.php
@@ -138,6 +138,23 @@ class Color
         return $this;
     }
 
+    public function center($width = 80, $text = null)
+    {
+        if ($text === null) {
+            $text = $this->_wrapped;
+        }
+
+        $centered = '';
+        foreach (explode(PHP_EOL, $text) as $line) {
+            $line = trim($line);
+            $width = strlen($line) - mb_strlen($line, 'UTF-8') + $width;
+            $centered .= str_pad($line, $width, ' ', STR_PAD_BOTH) . PHP_EOL;
+        }
+
+        $this->_setInternalState(trim($centered, PHP_EOL));
+        return $this;
+    }
+
     protected function _stripColors($text)
     {
         return preg_replace("/\033\[\d+m/", '', $text);

--- a/tests/Colors/ColorTest.php
+++ b/tests/Colors/ColorTest.php
@@ -182,4 +182,14 @@ class ColorsTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testCenter() {
+        $width = 80;
+        $color = new Color();
+        foreach (array('', 'hello', 'hello world!', '✩') as $text) {
+            $this->assertSame($width, mb_strlen($color($text)
+                ->center($width)->__toString(), 'UTF-8'));
+            $this->assertSame($width, mb_strlen($color($text)
+                ->center($width)->bg('blue')->clean()->__toString(), 'UTF-8'));
+        }
+    }
 }


### PR DESCRIPTION
Add support for a `center` method.
- Includes a test coverage
- Supports UTF-8 / multibyte strings
- Supports multiline strings

``` php
<?php
echo $c('')->center(80)->bg('blue') . PHP_EOL;
echo $c('Hello World!')->center(80)->white()->bold()->bg('blue') . PHP_EOL;
echo $c('This is centered text!')->center(80)->white()->bg('blue') . PHP_EOL;
echo $c('')->center(80)->bg('blue') . PHP_EOL;
```

![screen shot](http://cl.ly/image/2j432g0V0K24/Screen%20Shot%202012-08-19%20at%2011.32.39%20AM.png)

Did not add anything to the example file or documentation.
