### PR TITLE
Fix center bug

### DIFF
--- a/lib/Colors/Color.php
+++ b/lib/Colors/Color.php
@@ -147,8 +147,8 @@ class Color
         $centered = '';
         foreach (explode(PHP_EOL, $text) as $line) {
             $line = trim($line);
-            $width = strlen($line) - mb_strlen($line, 'UTF-8') + $width;
-            $centered .= str_pad($line, $width, ' ', STR_PAD_BOTH) . PHP_EOL;
+            $lineWidth = strlen($line) - mb_strlen($line, 'UTF-8') + $width;
+            $centered .= str_pad($line, $lineWidth, ' ', STR_PAD_BOTH) . PHP_EOL;
         }
 
         $this->_setInternalState(trim($centered, PHP_EOL));

--- a/tests/Colors/ColorTest.php
+++ b/tests/Colors/ColorTest.php
@@ -192,4 +192,15 @@ class ColorsTest extends \PHPUnit_Framework_TestCase
                 ->center($width)->bg('blue')->clean()->__toString(), 'UTF-8'));
         }
     }
+
+    public function testCenterMultiline() {
+        $width = 80;
+        $color = new Color();
+        $text = 'hello' . PHP_EOL . '✩' . PHP_EOL . 'world';
+
+        $actual = $color($text)->center($width)->__toString();
+        foreach(explode(PHP_EOL, $actual) as $line) {
+            $this->assertSame($width, mb_strlen($line, 'UTF-8'));
+        }
+    }
 }


### PR DESCRIPTION
When a multiline content is centered, the width variable is overrided by the multibyte width adjustement. 
