### PR TITLE
Forcetty option for use when colours are desired but php's STDOUT is not a tty

### DIFF
--- a/lib/Colors/Color.php
+++ b/lib/Colors/Color.php
@@ -11,6 +11,7 @@ class Color
 
     protected $_initial = '';
     protected $_wrapped = '';
+    protected $_forcetty = null;
     protected $_styles = array(
         // styles
         // italic and blink may not work depending of your terminal
@@ -42,9 +43,12 @@ class Color
     );
     protected $_theme = array();
 
-    public function __construct($string = '')
+    public function __construct($string = '', $forcetty = null)
     {
         $this->_setInternalState($string);
+        if (!is_null($forcetty)) {
+            $this->setForcetty($forcetty);
+        }
     }
 
     public function __invoke($string)
@@ -190,12 +194,21 @@ class Color
         return $this;
     }
 
+    public function setForcetty($forcetty)
+    {
+        $this->_forcetty = (bool) $forcetty;
+        return $this;
+    }
+
     /**
      * https://github.com/symfony/Console/blob/master/Output/StreamOutput.php#L93-112
      */
     public function isSupported()
     {
         // @codeCoverageIgnoreStart
+        if (!is_null($this->_forcetty)) {
+            return $this->_forcetty;
+        }   
         if (DIRECTORY_SEPARATOR == '\\') {
             return false !== getenv('ANSICON');
         }

--- a/tests/Colors/ColorTest.php
+++ b/tests/Colors/ColorTest.php
@@ -192,4 +192,21 @@ class ColorsTest extends \PHPUnit_Framework_TestCase
                 ->center($width)->bg('blue')->clean()->__toString(), 'UTF-8'));
         }
     }
+
+    public function testForcetty() {
+        $color = new Color();
+        $this->assertSame(true, $color->isSupported());
+
+        $color = new Color('', false);
+        $this->assertSame(false, $color->isSupported());
+
+        $color = new Color('', true);
+        $this->assertSame(true, $color->isSupported());
+
+        $color->setForcetty(true);
+        $this->assertSame(true, $color->isSupported());
+
+        $color->setForcetty(false);
+        $this->assertSame(false, $color->isSupported());
+    }
 }


### PR DESCRIPTION
Love the project. Thanks a lot for it. 

There are certain situations where forcing colors.php to output colors is desirable regardless of whether php is reporting that STDIN is a tty. In my particular situation grunt (node) is executing a php script using colors.php and I am unable to pass the tty to php regardless of what I do in node. Perhaps others will also experience a similar problem, and having the option will be as useful as it is to me.
