### PR TITLE
Adding simple singleton support

### DIFF
--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -65,6 +65,17 @@ class Color
     protected $userStyles = array();
     protected $isStyleForced = false;
 
+    /** @var Color */
+    protected static $instance;
+
+    public static function instance()
+    {
+        if (!self::$instance) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
     public function __construct($string = '')
     {
         $this->setInternalState($string);


### PR DESCRIPTION
This way it's possible to use `colorize()` more efficiently everywhere, without having to re-instance the class. Example: `echo Color::instance()->colorize('<bold>ERROR:</bold> You made a mistake');`