### PR TITLE
Added setString method

### DIFF
--- a/src/Colors/Color.php
+++ b/src/Colors/Color.php
@@ -93,6 +93,11 @@ class Color
     {
         return $this->wrapped;
     }
+    
+    public function setString($string)
+    {
+        return $this->setInternalState($string);
+    }
 
     public function setForceStyle($force)
     {


### PR DESCRIPTION
setString method can be used to set the content, `$c('Hello World!')` cannot be used in some situations.
```php
$c = new Color();
echo $c->setString('Hello World!')->white;
```